### PR TITLE
Removing unecessary wait time

### DIFF
--- a/NewWave/TaskEventBehavior.class.st
+++ b/NewWave/TaskEventBehavior.class.st
@@ -12,7 +12,7 @@ TaskEventBehavior >> performExecution: elemToExecute executor: wave [
 	| aFuture tktElem |
 	super performExecution: elemToExecute  executor: wave. 
 	tktElem := wave returnTKT: elemToExecute.
-	aFuture := wave worker future: [ 1 second wait. tktElem value ].
+	aFuture := wave worker future: [ tktElem value ].
 	aFuture onSuccessDo: [ :v |  v logCr. wave taskResult: v. wave tryToExecuteNext: elemToExecute ].
 	aFuture onFailureDo: [ :v | 'failed' logCr. v logCr. ]
 ]


### PR DESCRIPTION
My first impression using newwave was "why is it so slow ?".
I dont know why this wait time got introduced in the first place (maybe to debug easily) but we could have a seperated mecanism to introduce wait time (something like SlowTaskEventBehavior, which at would be explicit).
I think default behavior should not have this.

Btw, I think NewWave is a very cool implementation for workflows. Thanks for sharing it.