### PR TITLE
remove Teapot dependency

### DIFF
--- a/BaselineOfNewWave/BaselineOfNewWave.class.st
+++ b/BaselineOfNewWave/BaselineOfNewWave.class.st
@@ -9,20 +9,24 @@ BaselineOfNewWave >> baseline: spec [
 	<baseline>
 	spec
 		for: #common
-		do: [ 
-			"Dependencies"
+		do: [ "Dependencies"
 			self taskIt: spec.
+			self teapot: spec.
 			"self scheduler: spec."
 			self scheduler2: spec.
-			self teapot: spec.
+
 			"Packages"
+			spec package: 'NewWave' with: [spec requires: #(TaskIt Scheduler)].
 			spec
-				package: 'NewWave'.
-			spec	
-				package: 'NewWave-Server'.
-			spec	
-				package: 'NewWave-Plugin'.
-		]
+				package: 'NewWave-Server'
+				with: [ spec requires: #(NewWave Teapot) ].
+			spec package: 'NewWave-Plugin'.
+			"Groups"
+			spec group: 'Core' with: #(NewWave).
+			spec group: 'TeapotServer' with: #(Core Teapot).
+			spec
+				group: 'All'
+				with: #(Core TeapotServer 'NewWave-Plugin') ]
 ]
 
 { #category : #accessing }

--- a/NewWave-Server/WaveEngine.extension.st
+++ b/NewWave-Server/WaveEngine.extension.st
@@ -1,0 +1,13 @@
+Extension { #name : #WaveEngine }
+
+{ #category : #'*NewWave-Server' }
+WaveEngine >> server [ 
+	^ pluginData at: #NewWaveServer.
+]
+
+{ #category : #'*NewWave-Server' }
+WaveEngine >> startTeapotServer [
+	pluginData
+		at: #NewWaveServer
+		put: (NewWaveServer serveOn: 8081 waveEngine: self)
+]

--- a/NewWave/WaveEngine.class.st
+++ b/NewWave/WaveEngine.class.st
@@ -41,7 +41,7 @@ Class {
 		'workList',
 		'activations',
 		'scheduler',
-		'server'
+		'pluginData'
 	],
 	#category : #'NewWave-Engine'
 }
@@ -99,15 +99,15 @@ WaveEngine >> engineAnnouncer: anAnnouncer [
 ]
 
 { #category : #accessing }
-WaveEngine >> initialize [ 
+WaveEngine >> initialize [
 	super initialize.
 	self joinHandler: (JoinHandler context: self).
 	self subExecutors: OrderedCollection new.
 	self engineAnnouncer: Announcer new.
 	workList := WaveWorkList new.
 	activations := Dictionary new.
+	pluginData := Dictionary new
 	"scheduler := TaskScheduler new."
-	server := NewWaveServer serveOn: 8081 waveEngine: self.
 	"scheduler start."
 ]
 
@@ -144,11 +144,6 @@ WaveEngine >> scheduler [
 ]
 
 { #category : #accessing }
-WaveEngine >> server [ 
-	^ server.
-]
-
-{ #category : #accessing }
 WaveEngine >> startEngine [
 	mainExecutor tryToExecuteNext.
 	mainExecutor waveAnnouncer announce: StartAnnouncer new.
@@ -157,7 +152,7 @@ WaveEngine >> startEngine [
 { #category : #accessing }
 WaveEngine >> stopEngine [
 	"scheduler stop."
-	server stop.
+	pluginData do: [ :plugin | plugin stop ].
 	"I am force stopping all the workers in the engine."
 	mainExecutor workers valuesDo: [ :d | d stop ].
 ]


### PR DESCRIPTION
The teapot server should not be necessary to run a workflow. 
I created a couple of baseline groups so we can load the core engine without teapot and start the teapot serve on demand.


let me know if you think the groups are bad. I didnt change the default load, for retrocompatibility purpose, althought I think we should not load the teapot server by default.