### PR TITLE
Make NewWaveFieldUserTask loadable via baseline

### DIFF
--- a/BaselineOfNewWave/BaselineOfNewWave.class.st
+++ b/BaselineOfNewWave/BaselineOfNewWave.class.st
@@ -29,10 +29,11 @@ BaselineOfNewWave >> baseline: spec [
 			spec package: 'NewWave-Plugin'.
 			"Groups"
 			spec group: 'Core' with: #(NewWave).
+			spec group: 'WebTask' with: #( 'NewWaveFieldUserTask' ).
 			spec group: 'TeapotServer' with: #(Core Teapot).
 			spec
 				group: 'All'
-				with: #(Core TeapotServer 'NewWave-Plugin') ]
+				with: #(Core TeapotServer 'NewWave-Plugin' WebTask) ]
 ]
 
 { #category : #accessing }

--- a/BaselineOfNewWave/BaselineOfNewWave.class.st
+++ b/BaselineOfNewWave/BaselineOfNewWave.class.st
@@ -22,7 +22,7 @@ BaselineOfNewWave >> baseline: spec [
 
 			"Packages"
 			spec package: 'NewWave' with: [spec requires: #(TaskIt Scheduler)].
-			spec package: 'NewWaveFieldUserTask' with: [spec requires: #(Core ZincHTTPComponents NeoJSON Magritte Seaside3 Bootstrap)].
+			spec package: 'NewWaveFieldUserTask' with: [spec requires: #(Core ZincHTTPComponents NeoJSON Magritte Seaside3 Bootstrap 'NewWave-Server')].
 			spec
 				package: 'NewWave-Server'
 				with: [ spec requires: #(NewWave Teapot) ].

--- a/BaselineOfNewWave/BaselineOfNewWave.class.st
+++ b/BaselineOfNewWave/BaselineOfNewWave.class.st
@@ -51,7 +51,7 @@ BaselineOfNewWave >> magritte: spec [
 		with: [ 
 			spec 
 				loads: #( Seaside );
-				repository: 'github://magritte-metamodel/magritte:v3.6/source' ]
+				repository: 'github://magritte-metamodel/magritte:master/source' ]
 ]
 
 { #category : #accessing }

--- a/BaselineOfNewWave/BaselineOfNewWave.class.st
+++ b/BaselineOfNewWave/BaselineOfNewWave.class.st
@@ -17,10 +17,12 @@ BaselineOfNewWave >> baseline: spec [
 			self seaside: spec.
 			self bootstrap: spec.
 			self magritte: spec.
+			self neoJson: spec.
+			self zinc: spec.
 
 			"Packages"
 			spec package: 'NewWave' with: [spec requires: #(TaskIt Scheduler)].
-			spec package: 'NewWaveFieldUserTask' with: [spec requires: #(Core Magritte Seaside3 Bootstrap)].
+			spec package: 'NewWaveFieldUserTask' with: [spec requires: #(Core ZincHTTPComponents NeoJSON Magritte Seaside3 Bootstrap)].
 			spec
 				package: 'NewWave-Server'
 				with: [ spec requires: #(NewWave Teapot) ].
@@ -109,5 +111,14 @@ BaselineOfNewWave >> teapot: spec [
 		baseline: 'Teapot'
 		with: [ 
 			spec repository: 'github://zeroflag/teapot:master/source'
+		 ]
+]
+
+{ #category : #accessing }
+BaselineOfNewWave >> zinc: spec [
+	spec 
+		baseline: 'ZincHTTPComponents'
+		with: [ 
+			spec repository: 'github://svenvc/zinc:master/repository'
 		 ]
 ]

--- a/BaselineOfNewWave/BaselineOfNewWave.class.st
+++ b/BaselineOfNewWave/BaselineOfNewWave.class.st
@@ -51,7 +51,7 @@ BaselineOfNewWave >> magritte: spec [
 		with: [ 
 			spec 
 				loads: #( Seaside );
-				repository: 'github://magritte-metamodel/magritte:v3.6' ]
+				repository: 'github://magritte-metamodel/magritte:master' ]
 ]
 
 { #category : #accessing }
@@ -92,7 +92,7 @@ BaselineOfNewWave >> seaside: spec [
 	spec 
 		baseline: 'Seaside3'
 		with: [ 
-			spec repository: 'github://SeasideSt/Seaside:master/repository'
+			spec repository: 'github://SeasideSt/Seaside:develop/repository'
 		 ]
 ]
 

--- a/BaselineOfNewWave/BaselineOfNewWave.class.st
+++ b/BaselineOfNewWave/BaselineOfNewWave.class.st
@@ -14,9 +14,13 @@ BaselineOfNewWave >> baseline: spec [
 			self teapot: spec.
 			"self scheduler: spec."
 			self scheduler2: spec.
+			self seaside: spec.
+			self bootstrap: spec.
+			self magritte: spec.
 
 			"Packages"
 			spec package: 'NewWave' with: [spec requires: #(TaskIt Scheduler)].
+			spec package: 'NewWaveFieldUserTask' with: [spec requires: #(Core Magritte Seaside3 Bootstrap)].
 			spec
 				package: 'NewWave-Server'
 				with: [ spec requires: #(NewWave Teapot) ].
@@ -43,8 +47,9 @@ BaselineOfNewWave >> magritte: spec [
 	spec 
 		baseline: 'Magritte'
 		with: [ 
-			spec repository: 'github://magritte-metamodel/magritte:v3.5.4' 
-		 ]
+			spec 
+				loads: #( Seaside );
+				repository: 'github://magritte-metamodel/magritte:v3.6' ]
 ]
 
 { #category : #accessing }
@@ -83,7 +88,7 @@ BaselineOfNewWave >> scheduler: spec [
 { #category : #accessing }
 BaselineOfNewWave >> seaside: spec [
 	spec 
-		baseline: 'Seaside'
+		baseline: 'Seaside3'
 		with: [ 
 			spec repository: 'github://SeasideSt/Seaside:master/repository'
 		 ]

--- a/BaselineOfNewWave/BaselineOfNewWave.class.st
+++ b/BaselineOfNewWave/BaselineOfNewWave.class.st
@@ -51,7 +51,7 @@ BaselineOfNewWave >> magritte: spec [
 		with: [ 
 			spec 
 				loads: #( Seaside );
-				repository: 'github://magritte-metamodel/magritte:master' ]
+				repository: 'github://magritte-metamodel/magritte:v3.6/source' ]
 ]
 
 { #category : #accessing }
@@ -92,7 +92,7 @@ BaselineOfNewWave >> seaside: spec [
 	spec 
 		baseline: 'Seaside3'
 		with: [ 
-			spec repository: 'github://SeasideSt/Seaside:develop/repository'
+			spec repository: 'github://SeasideSt/Seaside:master/repository'
 		 ]
 ]
 


### PR DESCRIPTION
I've added all dependencies and the package to the baseline. Strange is that seaside seems to be a problem. For that reason it is now that seaside is loaded from develop branch and magritte from master. Later we can fix the version when the situation is solved. 
I could load all the could and start the seaside app. It breaks when the server is contacted. Here the routes and functionality seems to be missing