### PR TITLE
Try loading older but released version of zinc

### DIFF
--- a/BaselineOfNewWave/BaselineOfNewWave.class.st
+++ b/BaselineOfNewWave/BaselineOfNewWave.class.st
@@ -134,6 +134,6 @@ BaselineOfNewWave >> zinc: spec [
 	spec 
 		baseline: 'ZincHTTPComponents'
 		with: [ 
-			spec repository: 'github://svenvc/zinc:master/repository'
+			spec repository: 'github://svenvc/zinc:v3.0.1/repository'
 		 ]
 ]


### PR DESCRIPTION
Something was not properly with newest zinc. As we are targetting pharo7 I guess I pinned zinc to version v3.0.1